### PR TITLE
Changed publishing topic from odom to pose

### DIFF
--- a/include/PX4_realsense_bridge/PX4_realsense_bridge.h
+++ b/include/PX4_realsense_bridge/PX4_realsense_bridge.h
@@ -2,6 +2,7 @@
 #define PX4_REALSENSE_BRIDGE
 
 #include <nav_msgs/Odometry.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <mavros_msgs/CompanionProcessStatus.h>
 #include <ros/ros.h>
 #include <tf/transform_broadcaster.h>
@@ -39,7 +40,7 @@ class PX4_Realsense_Bridge {
   // Subscribers
   ros::Subscriber odom_sub_;
   // Publishers
-  ros::Publisher mavros_odom_pub_;
+  ros::Publisher mavros_pose_pub_;
   ros::Publisher mavros_system_status_pub_;
 
   MAV_STATE system_status_{MAV_STATE::MAV_STATE_UNINIT};


### PR DESCRIPTION
The px4_realsense_bridge pkg doesn't work as it publishes on the /mavros/odometry/out topic which for some reason is not recognized by the px4, instead when published on /mavros/vision_pose/pose it will show up odometry message. This is validated by checking ekf2 status in the QGC console and it will show the local position as valid and ODOMETRY message in logs.