### PR TITLE
Revert "Changed publishing topic from odom to pose"

### DIFF
--- a/include/PX4_realsense_bridge/PX4_realsense_bridge.h
+++ b/include/PX4_realsense_bridge/PX4_realsense_bridge.h
@@ -2,7 +2,6 @@
 #define PX4_REALSENSE_BRIDGE
 
 #include <nav_msgs/Odometry.h>
-#include <geometry_msgs/PoseStamped.h>
 #include <mavros_msgs/CompanionProcessStatus.h>
 #include <ros/ros.h>
 #include <tf/transform_broadcaster.h>
@@ -40,7 +39,7 @@ class PX4_Realsense_Bridge {
   // Subscribers
   ros::Subscriber odom_sub_;
   // Publishers
-  ros::Publisher mavros_pose_pub_;
+  ros::Publisher mavros_odom_pub_;
   ros::Publisher mavros_system_status_pub_;
 
   MAV_STATE system_status_{MAV_STATE::MAV_STATE_UNINIT};

--- a/src/nodes/px4_realsense_bridge.cpp
+++ b/src/nodes/px4_realsense_bridge.cpp
@@ -10,12 +10,13 @@ namespace bridge {
 
 PX4_Realsense_Bridge::PX4_Realsense_Bridge(const ros::NodeHandle& nh)
     : nh_(nh) {
+
   // initialize subscribers
   odom_sub_ = nh_.subscribe<const nav_msgs::Odometry&>(
       "/camera/odom/sample_throttled", 10, &PX4_Realsense_Bridge::odomCallback, this);
   // publishers
-  mavros_pose_pub_ = 
-      nh_.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose", 10);
+  mavros_odom_pub_ =
+      nh_.advertise<nav_msgs::Odometry>("/mavros/odometry/out", 10);
   mavros_system_status_pub_ =
       nh_.advertise<mavros_msgs::CompanionProcessStatus>("/mavros/companion_process/status", 1);
 
@@ -23,17 +24,20 @@ PX4_Realsense_Bridge::PX4_Realsense_Bridge(const ros::NodeHandle& nh)
 
   status_mutex_.reset(new std::mutex);
   worker_ = std::thread(&PX4_Realsense_Bridge::publishSystemStatus, this);
+
+
 };
 
 PX4_Realsense_Bridge::~PX4_Realsense_Bridge() { }
 
+
 void PX4_Realsense_Bridge::odomCallback(const nav_msgs::Odometry& msg) {
-  // stamp and frame id are needed for the mavros odometry msg for to be received by uorb topics
-  geometry_msgs::PoseStamped output;
-  output.header.stamp = ros::Time::now();
+
+  // publish odometry msg
+  nav_msgs::Odometry output = msg;
   output.header.frame_id = msg.header.frame_id;
-  output.pose = msg.pose.pose;
-  mavros_pose_pub_.publish(output);
+  output.child_frame_id = msg.child_frame_id;
+  mavros_odom_pub_.publish(output);
 
   flag_first_pose_received = true;
 


### PR DESCRIPTION
This reverts PR #15 

The velocity information is dropped by only using the pose, which means that PX4 side will only work with position fusion (which we've found to perform worse). The issue fixed there was probably coming from MAVROS (was the odometry plugin loaded?)