### PR TITLE
ability to launch bridge node with a namespace

### DIFF
--- a/launch/bridge.launch
+++ b/launch/bridge.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="ns" default="/"/>
 
   <!-- Launch static transform publishers -->
   <node pkg="tf" type="static_transform_publisher" name="tf_baseLink_cameraPose"
@@ -39,8 +40,10 @@
   <arg name="input_topic" default="[/camera/odom/sample]"/>
 
   <!-- Bridge node -->
-  <node name="px4_realsense_bridge_node" pkg="px4_realsense_bridge" type="px4_realsense_bridge_node" output="screen" >
-    <rosparam param="input_topic" subst_value="True">$(arg input_topic)</rosparam>
-  </node>
+  <group ns="$(arg ns)">
+    <node name="px4_realsense_bridge_node" pkg="px4_realsense_bridge" type="px4_realsense_bridge_node" output="screen" >
+      <rosparam param="input_topic" subst_value="True">$(arg input_topic)</rosparam>
+    </node>
+  </group>
 
 </launch>

--- a/launch/bridge_mavros.launch
+++ b/launch/bridge_mavros.launch
@@ -7,6 +7,7 @@
   
   <!-- Launch bridge -->
   <include file="$(find px4_realsense_bridge)/launch/bridge.launch" >
+    <arg name="ns" value="$(arg ns)" />
   </include>
 
   <!-- Launch MavROS -->

--- a/launch/bridge_mavros_sitl.launch
+++ b/launch/bridge_mavros_sitl.launch
@@ -15,6 +15,7 @@
 
   <!-- Launch bridge -->
   <include file="$(find px4_realsense_bridge)/launch/bridge.launch" >
+    <arg name="ns" value="$(arg ns)" />
   </include>
   
   <!-- Launch PX4 SITL -->

--- a/src/nodes/px4_realsense_bridge.cpp
+++ b/src/nodes/px4_realsense_bridge.cpp
@@ -15,10 +15,11 @@ PX4_Realsense_Bridge::PX4_Realsense_Bridge(const ros::NodeHandle& nh)
   odom_sub_ = nh_.subscribe<const nav_msgs::Odometry&>(
       "/camera/odom/sample_throttled", 10, &PX4_Realsense_Bridge::odomCallback, this);
   // publishers
+  std::string ns = ros::this_node::getNamespace();
   mavros_odom_pub_ =
-      nh_.advertise<nav_msgs::Odometry>("/mavros/odometry/out", 10);
+      nh_.advertise<nav_msgs::Odometry>(ns+"/mavros/odometry/out", 10);
   mavros_system_status_pub_ =
-      nh_.advertise<mavros_msgs::CompanionProcessStatus>("/mavros/companion_process/status", 1);
+      nh_.advertise<mavros_msgs::CompanionProcessStatus>(ns+"/mavros/companion_process/status", 1);
 
   last_callback_time = ros::Time::now();
 


### PR DESCRIPTION
I added the ability to launch the bridge node with a namespace.

The problem was that bridge_mavros.launch and bridge_mavros_sitl.launch allow users to launch mavros with a namespace. However, bridge.launch didn't allow a namespace and therefore ~/catkin_ws/src/VIO/src/nodes/px4_realsense_bridge.cpp file wasn't publishing to the right topics. 

For example, `roslaunch px4_realsense_bridge bridge_mavros.launch ns:=captain` was resulting with 

```
/mavros/companion_process/status
/mavros/odometry/out
```
**and**
```
/captain/mavros/companion_process/status
/captain/mavros/odometry/out
```
As a result, `px4_realsense_bridge_node` was publishing on the wrong topics.

I fixed this problem with my PR, `roslaunch px4_realsense_bridge bridge_mavros.launch ns:=captain` creates only

```
/captain/mavros/companion_process/status
/captain/mavros/odometry/out
```
and `roslaunch px4_realsense_bridge bridge_mavros.launch` creates

```
/mavros/companion_process/status
/mavros/odometry/out
```

If the user decides to launch mavros using a custom launch file (not bridge_mavros.launch nor bridge_mavros_sitl.launch) and use bridge.launch file separately, `roslaunch px4_realsense_bridge bridge.launch` and `roslaunch px4_realsense_bridge bridge.launch ns:=captain` work too.
